### PR TITLE
use 2048bit key

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -11,7 +11,7 @@ locals {
 
 resource "tls_private_key" "signing" {
   algorithm = "RSA"
-  rsa_bits  = 4096
+  rsa_bits  = 2048
 }
 
 resource "kubernetes_secret" "signing_key" {


### PR DESCRIPTION
upload of 4096bit key results in Your request contains empty/invalid/out of limits RSA Encoded Key